### PR TITLE
Torque/thrust changes

### DIFF
--- a/MechJebRCSFXExt.cs
+++ b/MechJebRCSFXExt.cs
@@ -35,9 +35,8 @@ namespace MechJebRCSFXExt
             Vector3 inputLinear = vessel.ReferenceTransform.rotation * Vector3.one;
 
             int xformCount = rcs.thrusterTransforms.Count;
-            bool success; // Just to pass to rcs.CalculateThrust(). Probably not going to use it. Or might!
 
-            float thrustBase = rcs.CalculateThrust(1f, out success);
+            double thrustBase = rcs.flowMult * rcs.fuelFlow * rcs.realISP * rcs.G * rcs.ispMult;
 
             for (int i = 0; i < xformCount; ++i)
             {
@@ -77,7 +76,7 @@ namespace MechJebRCSFXExt
                         }
                     }
 
-                    float thrustForce = thrustBase * thrust;
+                    float thrustForce = (float)thrustBase * thrust;
 
                     Vector3 force = vessel.GetTransform().InverseTransformDirection(thrustForce * thruster);
 

--- a/MechJebRCSFXExt.cs
+++ b/MechJebRCSFXExt.cs
@@ -35,8 +35,9 @@ namespace MechJebRCSFXExt
             Vector3 inputLinear = vessel.ReferenceTransform.rotation * Vector3.one;
 
             int xformCount = rcs.thrusterTransforms.Count;
+            bool success; // Just to pass to rcs.CalculateThrust(). Probably not going to use it. Or might!
 
-            double thrustBase = rcs.flowMult * rcs.fuelFlow * rcs.realISP * rcs.G * rcs.ispMult;
+            float thrustBase = rcs.CalculateThrust(1f, out success);
 
             for (int i = 0; i < xformCount; ++i)
             {
@@ -48,10 +49,12 @@ namespace MechJebRCSFXExt
                     Vector3 torque = Vector3.Cross(inputAngular.normalized, relPos.normalized);
 
                     Vector3 thruster = rcs.useZaxis ? xform.forward : xform.up;
+                    float leverDistance = rcs.GetLeverDistance(-thruster, vessel.CoM);
+
 
                     float thrust = Mathf.Max(Vector3.Dot(thruster, torque), 0f);
                     thrust += Mathf.Max(Vector3.Dot(thruster, inputLinear.normalized), 0f);
-                    
+
                     //if (thrust <= 0f)
                     //{
                     //    print("Ignore " + thrust.ToString("F2") + " " + Vector3.Dot(thruster, torque).ToString("F2") + " " + Vector3.Dot(thruster, inputLinear.normalized).ToString("F2"));
@@ -62,7 +65,6 @@ namespace MechJebRCSFXExt
                     {
                         if (rcs.useLever)
                         {
-                            float leverDistance = rcs.GetLeverDistance(-thruster, CoM);
 
                             if (leverDistance > 1)
                             {
@@ -74,16 +76,17 @@ namespace MechJebRCSFXExt
                             thrust *= rcs.precisionFactor;
                         }
                     }
-                    
-                    float thrustForce = (float)thrustBase * thrust;
 
-                    Vector3 force = vessel.GetTransform().InverseTransformDirection(-thrustForce * thruster);
+                    float thrustForce = thrustBase * thrust;
+
+                    Vector3 force = vessel.GetTransform().InverseTransformDirection(thrustForce * thruster);
 
                     force.Scale(new Vector3(rcs.enableX ? 1f : 0f, rcs.enableZ ? 1f : 0f, rcs.enableY ? 1f : 0f));
-                    
+
                     vesselState.rcsThrustAvailable.Add(force);
-                    
-                    Vector3 thrusterTorque = vessel.GetTransform().InverseTransformDirection(Vector3.Cross(relPos, force));
+
+                    //Vector3d thrusterTorque = Vector3.Cross(relPos, -thruster) * leverDistance * thrustBase;
+                    Vector3d thrusterTorque = thruster * (leverDistance * thrustForce);
                     // Convert in vessel local coordinate
 
                     thruster.Scale(new Vector3d(rcs.enablePitch ? 1f : 0f, rcs.enableRoll ? 1f : 0f, rcs.enableYaw ? 1f : 0));


### PR DESCRIPTION
- Get thrustBase by querying rcs.CalculateThrust()
- Always compute leverDistance (instead of just for precision mode) and
  used it in later calculations
- Compute torque using leverDistance \* thrustForce. (relative position
  vector may not always be perpendicular to force vector and cross product
  in torque calculations requires it)
